### PR TITLE
Change computation variable naming to avoid confusion

### DIFF
--- a/xirr.js
+++ b/xirr.js
@@ -56,7 +56,8 @@ function convert(data) {
 function xirr(transactions, options) {
     var data = convert(transactions);
     var investments = data.investments;
-    var presentValue = function(rate) {
+    // IRR calculation works w/ present or future value, future used to avoid division
+    var futureValue = function(rate) {
         return investments.reduce(function(sum, investment) {
             // Make the vars more Math-y, makes the derivative easier to see
             var A = investment.amount;
@@ -77,7 +78,7 @@ function xirr(transactions, options) {
         }, 0);
     };
     var guess = (data.total / data.deposits) / (data.days/DAYS_IN_YEAR);
-    var rate = newton(presentValue, derivative, guess, options);
+    var rate = newton(futureValue, derivative, guess, options);
     if (rate === false) {  // truthiness strikes again, !rate is true when rate is zero
         throw new Error("Newton-Raphson algorithm failed to converge.");
     }


### PR DESCRIPTION
The sum being used in the IRR calculation is the future value of the cash flow, not the present value as the variable name would suggest. The variable name was changed to reflect this in order to prevent any confusion when others inspect the source code. A comment was added to explain why this is done as traditionally the present value is used in IRR calculations.