### PR TITLE
xirr: Passing guess as an option

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -152,6 +152,14 @@ describe('xirr', function() {
         assert.equal(0.0785780, result.toPrecision(6));
     });
 
+    it('Take guess as option', function() {
+        var transactions = [];
+        transactions.push({ amount: -1000, when: new Date(2010,0,1) });
+        transactions.push({ amount: 1100, when: new Date(2011,0,1) });
+        var result = xirr(transactions,  { guess: 0.1 } );
+        assert.equal(0.100000, result.toPrecision(6));
+    });
+
     describe('failure modes', function() {
         it('throws an exception when Newton\'s method fails', sinon.test(function() {
             var newtonStub = sinon.stub();
@@ -198,6 +206,14 @@ describe('xirr', function() {
             transactions.push({ amount: 0, when: new Date(2010, 8, 1) });
             assert.throws(function() { xirr(transactions); },
                 /Transactions must not all be nonnegative./);
+        });
+
+        it('NAN guess as option', function() {
+            var transactions = [];
+            transactions.push({ amount: -1000, when: new Date(2010,0,1) });
+            transactions.push({ amount: 1100, when: new Date(2011,0,1) });
+            assert.throws(function() { xirr(transactions, { guess: "10%" }); },
+                /option.guess must be a number./);
         });
     });
 });

--- a/xirr.js
+++ b/xirr.js
@@ -109,7 +109,13 @@ function xirr(transactions, options) {
             }
         }, 0);
     };
-    var guess = (data.total / data.deposits) / (data.days/DAYS_IN_YEAR);
+    var { guess } = options || {};
+    if (guess && isNaN(guess)) {
+        throw new Error("option.guess must be a number.");
+    }
+    if (!guess) {
+        guess = (data.total / data.deposits) / (data.days/DAYS_IN_YEAR);
+    }
     var rate = newton(value, derivative, guess, options);
     if (rate === false) {  // truthiness strikes again, !rate is true when rate is zero
         throw new Error("Newton-Raphson algorithm failed to converge.");


### PR DESCRIPTION
Currently guess is made from a hard logic which
is a part of the npm. Extending guess as an option
which can be collected from the trigger.

Signed-off-by: Yogesh Ashok Powar <yogesh@orowealth.com>